### PR TITLE
Improve consistency of adjoint derivative types

### DIFF
--- a/demos/ErrorEstimation/FloatSum.cpp
+++ b/demos/ErrorEstimation/FloatSum.cpp
@@ -104,9 +104,9 @@ int main() {
 
     // Clear the final error
     finalError = 0;
-
+    unsigned int dn = 0;
     // First execute the derived function.
-    df.execute(x, n, &ret[0], &ret[1], finalError);
+    df.execute(x, n, &ret[0], &dn, finalError);
 
     double kahanResult = kahanSum(x, n);
     double vanillaResult = vanillaSum(x, n);

--- a/include/clad/Differentiator/BuiltinDerivatives.h
+++ b/include/clad/Differentiator/BuiltinDerivatives.h
@@ -70,11 +70,10 @@ CUDA_HOST_DEVICE ValueAndPushforward<T, T> log_pushforward(T x, T d_x) {
   return {::std::log(x), static_cast<T>((1.0 / x) * d_x)};
 }
 
-template <typename T1, typename T2>
-CUDA_HOST_DEVICE void
-pow_pullback(T1 x, T2 exponent, decltype(::std::pow(T1(), T2())) d_y,
-             clad::array_ref<decltype(::std::pow(T1(), T2()))> d_x,
-             clad::array_ref<decltype(::std::pow(T1(), T2()))> d_exponent) {
+template <typename T1, typename T2, typename T3>
+CUDA_HOST_DEVICE void pow_pullback(T1 x, T2 exponent, T3 d_y,
+                                   clad::array_ref<decltype(T1())> d_x,
+                                   clad::array_ref<decltype(T2())> d_exponent) {
   auto t = pow_pushforward(x, exponent, static_cast<T1>(1), static_cast<T2>(0));
   *d_x += t.pushforward * d_y;
   t = pow_pushforward(x, exponent, static_cast<T1>(0), static_cast<T2>(1));

--- a/include/clad/Differentiator/FunctionTraits.h
+++ b/include/clad/Differentiator/FunctionTraits.h
@@ -368,7 +368,7 @@ namespace clad {
       DropArgs_AddCON((, ...)); // Declares all the specializations
 
   template <class T, class R> struct OutputParamType {
-    using type = array_ref<R>;
+    using type = array_ref<typename std::remove_pointer<R>::type>;
   };
 
   template <class T, class R>
@@ -462,7 +462,7 @@ namespace clad {
   // GradientDerivedEstFnTraits specializations for pure function pointer types
   template <class ReturnType, class... Args>
   struct GradientDerivedEstFnTraits<ReturnType (*)(Args...)> {
-    using type = void (*)(Args..., OutputParamType_t<Args, ReturnType>...,
+    using type = void (*)(Args..., OutputParamType_t<Args, Args>...,
                           double&);
   };
 
@@ -478,7 +478,7 @@ namespace clad {
 #define GradientDerivedEstFnTraits_AddSPECS(var, cv, vol, ref, noex)           \
   template <typename R, typename C, typename... Args>                          \
   struct GradientDerivedEstFnTraits<R (C::*)(Args...) cv vol ref noex> {       \
-    using type = void (C::*)(Args..., OutputParamType_t<Args, R>...,           \
+    using type = void (C::*)(Args..., OutputParamType_t<Args, Args>...,           \
                              double&) cv vol ref noex;                         \
   };
 

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -568,6 +568,8 @@ namespace clad {
     /// function.
     llvm::SmallVector<clang::ParmVarDecl*, 8>
     BuildParams(DiffParams& diffParams);
+
+    clang::QualType ComputeAdjointType(clang::QualType T);
   };
 } // end namespace clad
 

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -1182,15 +1182,7 @@ namespace clad {
     // Save current index in the current block, to potentially put some
     // statements there later.
     std::size_t insertionPoint = getCurrentBlock(direction::reverse).size();
-    // Store the type to reduce call overhead that would occur if used in the
-    // loop
-    // auto CEType = getNonConstType(CE->getType(), m_Context, m_Sema);
-    // // Use `double` as the placeholder type for the derivatives when the funtion
-    // // return type is void. We need to do this because we are using function
-    // // return type to compute the derivative type of the arguments. See
-    // // https://github.com/vgvassilev/clad/issues/385 for more details.
-    // if (CEType->isVoidType())
-    //   CEType = m_Context.DoubleTy;
+
     // FIXME: We should add instructions for handling non-differentiable
     // arguments. Currently we are implicitly assuming function call only
     // contains differentiable arguments.
@@ -2877,12 +2869,6 @@ namespace clad {
         auto it = std::find(std::begin(diffParams), std::end(diffParams), PVD);
         if (it != std::end(diffParams))
           paramTypes.push_back(ComputeAdjointType(PVD->getType()));
-          // if (PVD->getType()->isAnyPointerType()) {
-          //   paramTypes.push_back(GetCladArrayRefOfType(PVD->getType()->getPointeeType()));
-          // }
-          // else {
-          //   paramTypes.push_back(GetCladArrayRefOfType(PVD->getType().getNonReferenceType()));
-          // }
       }
     } else if (m_Mode == DiffMode::jacobian) {
       std::size_t lastArgIdx = m_Function->getNumParams() - 1;

--- a/test/Arrays/ArrayInputsReverseMode.C
+++ b/test/Arrays/ArrayInputsReverseMode.C
@@ -49,12 +49,12 @@ double f(double *arr) {
 //CHECK-NEXT:       double f_return = addArr(arr, 3);
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
-//CHECK-NEXT:       {
-//CHECK-NEXT:         int _grad1 = 0.;
+//CHECK-NEXT:     {
+//CHECK-NEXT:         int _grad1 = 0;
 //CHECK-NEXT:         addArr_pullback(_t0, 3, 1, _d_arr, &_grad1);
 //CHECK-NEXT:         clad::array<double> _r0(_d_arr);
-//CHECK-NEXT:         double _r1 = _grad1;
-//CHECK-NEXT:       }
+//CHECK-NEXT:         int _r1 = _grad1;
+//CHECK-NEXT:     }
 //CHECK-NEXT:   }
 
 float func(float* a, float* b) {

--- a/test/ErrorEstimation/BasicOps.C
+++ b/test/ErrorEstimation/BasicOps.C
@@ -401,7 +401,7 @@ float func8(float x, float y) {
 //CHECK-NEXT:     {
 //CHECK-NEXT:         * _d_y += _d_z;
 //CHECK-NEXT:         helper2_pullback(_t0, _d_z, &* _d_x);
-//CHECK-NEXT:         double _r0 = * _d_x;
+//CHECK-NEXT:         float _r0 = * _d_x;
 //CHECK-NEXT:         _delta_z += _d_z * _EERepl_z0 * {{.+}};
 //CHECK-NEXT:         _final_error += _r0 * _t0 * {{.+}};
 //CHECK-NEXT:     }

--- a/test/ErrorEstimation/LoopsAndArraysExec.C
+++ b/test/ErrorEstimation/LoopsAndArraysExec.C
@@ -67,7 +67,7 @@ double mulSum(float* a, float* b, int n) {
   return sum;
 }
 
-//CHECK: void mulSum_grad(float *a, float *b, int n, clad::array_ref<double> _d_a, clad::array_ref<double> _d_b, clad::array_ref<double> _d_n, double &_final_error) {
+//CHECK: void mulSum_grad(float *a, float *b, int n, clad::array_ref<float> _d_a, clad::array_ref<float> _d_b, clad::array_ref<int> _d_n, double &_final_error) {
 //CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     double _delta_sum = 0;
 //CHECK-NEXT:     double _EERepl_sum0;
@@ -140,7 +140,7 @@ double divSum(float* a, float* b, int n) {
   return sum;
 }
 
-//CHECK: void divSum_grad(float *a, float *b, int n, clad::array_ref<double> _d_a, clad::array_ref<double> _d_b, clad::array_ref<double> _d_n, double &_final_error) {
+//CHECK: void divSum_grad(float *a, float *b, int n, clad::array_ref<float> _d_a, clad::array_ref<float> _d_b, clad::array_ref<int> _d_n, double &_final_error) {
 //CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     double _delta_sum = 0;
 //CHECK-NEXT:     double _EERepl_sum0;
@@ -200,8 +200,10 @@ double divSum(float* a, float* b, int n) {
 int main() {
   auto df = clad::estimate_error(runningSum);
   float arrf[3] = {0.456, 0.77, 0.95};
-  double finalError = 0, dn = 0, darr[3] = {0, 0, 0};
-  clad::array_ref<double> darrRef(darr, 3);
+  double finalError = 0;
+  float darr[3] = {0, 0, 0};
+  int dn = 0;
+  clad::array_ref<float> darrRef(darr, 3);
   df.execute(arrf, 3, darrRef, &dn, finalError);
   printf("Result (RS) = {%.2f, %.2f, %.2f} error = %.5f\n", darr[0], darr[1],
          darr[2], finalError); // CHECK-EXEC: Result (RS) = {1.00, 2.00, 1.00} error = 0.00000
@@ -209,8 +211,8 @@ int main() {
   finalError = 0;
   darr[0] = darr[1] = darr[2] = 0;
   dn = 0;
-  double darr2[3] = {0, 0, 0};
-  clad::array_ref<double> darrRef2(darr2, 3);
+  float darr2[3] = {0, 0, 0};
+  clad::array_ref<float> darrRef2(darr2, 3);
   auto df2 = clad::estimate_error(mulSum);
   df2.execute(arrf, arrf, 3, darrRef, darrRef2, &dn, finalError);
   printf("Result (MS) = {%.2f, %.2f, %.2f}, {%.2f, %.2f, %.2f}  error = %.5f\n",

--- a/test/FirstDerivative/BuiltinDerivatives.C
+++ b/test/FirstDerivative/BuiltinDerivatives.C
@@ -106,12 +106,12 @@ void f7_grad(float x, clad::array_ref<float> _d_x);
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
-// CHECK-NEXT:         typename {{.*}} _grad0 = 0.;
-// CHECK-NEXT:         typename {{.*}} _grad1 = 0.;
-// CHECK-NEXT:         clad::custom_derivatives{{(::std)?}}::pow_pullback(_t0, 2., 1, &_grad0, &_grad1);
-// CHECK-NEXT:         typename {{.*}} _r0 = _grad0;
+// CHECK-NEXT:         float _grad0 = 0.F;
+// CHECK-NEXT:         double _grad1 = 0.;
+// CHECK-NEXT:         clad::custom_derivatives::std::pow_pullback(_t0, 2., 1, &_grad0, &_grad1);
+// CHECK-NEXT:         float _r0 = _grad0;
 // CHECK-NEXT:         * _d_x += _r0;
-// CHECK-NEXT:         typename {{.*}} _r1 = _grad1;
+// CHECK-NEXT:         double _r1 = _grad1;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -134,12 +134,12 @@ void f8_grad(float x, clad::array_ref<float> _d_x);
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
-// CHECK-NEXT:         typename {{.*}} _grad0 = 0.;
-// CHECK-NEXT:         typename {{.*}} _grad1 = 0.;
-// CHECK-NEXT:         clad::custom_derivatives{{(::std)?}}::pow_pullback(_t0, 2, 1, &_grad0, &_grad1);
-// CHECK-NEXT:         typename {{.*}} _r0 = _grad0;
+// CHECK-NEXT:         float _grad0 = 0.F;
+// CHECK-NEXT:         int _grad1 = 0;
+// CHECK-NEXT:         clad::custom_derivatives::std::pow_pullback(_t0, 2, 1, &_grad0, &_grad1);
+// CHECK-NEXT:         float _r0 = _grad0;
 // CHECK-NEXT:         * _d_x += _r0;
-// CHECK-NEXT:         typename {{.*}} _r1 = _grad1;
+// CHECK-NEXT:         int _r1 = _grad1;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -167,7 +167,7 @@ void f9_grad(float x, float y, clad::array_ref<float> _d_x, clad::array_ref<floa
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _grad0 = 0.F;
 // CHECK-NEXT:         float _grad1 = 0.F;
-// CHECK-NEXT:         clad::custom_derivatives{{(::std)?}}::pow_pullback(_t0, _t1, 1, &_grad0, &_grad1);
+// CHECK-NEXT:         clad::custom_derivatives::std::pow_pullback(_t0, _t1, 1, &_grad0, &_grad1);
 // CHECK-NEXT:         float _r0 = _grad0;
 // CHECK-NEXT:         * _d_x += _r0;
 // CHECK-NEXT:         float _r1 = _grad1;
@@ -197,12 +197,12 @@ void f10_grad(float x, int y, clad::array_ref<float> _d_x, clad::array_ref<int> 
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
-// CHECK-NEXT:         typename {{.*}} _grad0 = 0.;
-// CHECK-NEXT:         typename {{.*}} _grad1 = 0.;
-// CHECK-NEXT:         clad::custom_derivatives{{(::std)?}}::pow_pullback(_t0, _t1, 1, &_grad0, &_grad1);
-// CHECK-NEXT:         typename {{.*}} _r0 = _grad0;
+// CHECK-NEXT:         float _grad0 = 0.F;
+// CHECK-NEXT:         int _grad1 = 0;
+// CHECK-NEXT:         clad::custom_derivatives::std::pow_pullback(_t0, _t1, 1, &_grad0, &_grad1);
+// CHECK-NEXT:         float _r0 = _grad0;
 // CHECK-NEXT:         * _d_x += _r0;
-// CHECK-NEXT:         typename {{.*}} _r1 = _grad1;
+// CHECK-NEXT:         int _r1 = _grad1;
 // CHECK-NEXT:         * _d_y += _r1;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -247,10 +247,10 @@ int main () { //expected-no-diagnostics
   auto f8_darg0 = clad::differentiate(f8, 0);
   printf("Result is = %f\n", f8_darg0.execute(3)); //CHECK-EXEC: Result is = 6.000000
 
-  d_result[0] = 0;
+  f_result[0] = 0;
   clad::gradient(f8);
-  f8_grad(3, d_result);
-  printf("Result is = %f\n", d_result[0]); //CHECK-EXEC: Result is = 6.000000
+  f8_grad(3, f_result);
+  printf("Result is = %f\n", f_result[0]); //CHECK-EXEC: Result is = 6.000000
 
   auto f9_darg0 = clad::differentiate(f9, 0);
   printf("Result is = %f\n", f9_darg0.execute(3, 4)); //CHECK-EXEC: Result is = 108.000000
@@ -263,10 +263,10 @@ int main () { //expected-no-diagnostics
   auto f10_darg0 = clad::differentiate(f10, 0);
   printf("Result is = %f\n", f10_darg0.execute(3, 4)); //CHECK-EXEC: Result is = 108.000000
 
-  d_result[0] = d_result[1] = 0;
-  // clad::gradient(f10);
-  // f10_grad(3, 4, &d_result[0], &i_result[0]);
-  // printf("Result is = {%f, %f}\n", d_result[0], i_result[0]); //CHECK-EXEC: Result is = {108.000000, 88.987597}
+  f_result[0] = f_result[1] = 0;
+  clad::gradient(f10);
+  f10_grad(3, 4, &f_result[0], &i_result[0]);
+  printf("Result is = {%f, %d}\n", f_result[0], i_result[0]); //CHECK-EXEC: Result is = {108.000000, 88}
 
   return 0;
 }

--- a/test/Gradient/FunctionCalls.C
+++ b/test/Gradient/FunctionCalls.C
@@ -195,7 +195,7 @@ float sum(double* arr, int n) {
   return res;
 }
 
-// CHECK: void sum_pullback(double *arr, int n, float _d_y, clad::array_ref<float> _d_arr, clad::array_ref<float> _d_n) {
+// CHECK: void sum_pullback(double *arr, int n, float _d_y, clad::array_ref<double> _d_arr, clad::array_ref<int> _d_n) {
 // CHECK-NEXT:     float _d_res = 0;
 // CHECK-NEXT:     unsigned long _t0;
 // CHECK-NEXT:     int _d_i = 0;
@@ -214,10 +214,10 @@ float sum(double* arr, int n) {
 // CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         float _r_d1 = _d_arr[0];
+// CHECK-NEXT:         double _r_d1 = _d_arr[0];
 // CHECK-NEXT:         _d_arr[0] += _r_d1;
 // CHECK-NEXT:         double _r0 = _r_d1 * _t3;
-// CHECK-NEXT:         float _r1 = 10 * _r_d1;
+// CHECK-NEXT:         double _r1 = 10 * _r_d1;
 // CHECK-NEXT:         _d_arr[0] += _r1;
 // CHECK-NEXT:         _d_arr[0] -= _r_d1;
 // CHECK-NEXT:         _d_arr[0];
@@ -259,7 +259,7 @@ double fn4(double* arr, int n) {
   return res;
 }
 
-// CHECK: void fn4_grad(double *arr, int n, clad::array_ref<double> _d_arr, clad::array_ref<double> _d_n) {
+// CHECK: void fn4_grad(double *arr, int n, clad::array_ref<double> _d_arr, clad::array_ref<int> _d_n) {
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double *_t0;
 // CHECK-NEXT:     int _t1;
@@ -303,13 +303,11 @@ double fn4(double* arr, int n) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r_d0 = _d_res;
 // CHECK-NEXT:         _d_res += _r_d0;
-// CHECK-NEXT:         clad::array<float> _grad0(_d_arr);
-// CHECK-NEXT:         float _grad1 = 0.F;
-// CHECK-NEXT:         sum_pullback(_t0, _t1, _r_d0, _grad0, &_grad1);
-// CHECK-NEXT:         clad::array<float> _r0(_d_arr);
-// CHECK-NEXT:         float _r1 = _grad1;
+// CHECK-NEXT:         int _grad1 = 0;
+// CHECK-NEXT:         sum_pullback(_t0, _t1, _r_d0, _d_arr, &_grad1);
+// CHECK-NEXT:         clad::array<double> _r0(_d_arr);
+// CHECK-NEXT:         int _r1 = _grad1;
 // CHECK-NEXT:         * _d_n += _r1;
-// CHECK-NEXT:         _d_arr = _grad0;
 // CHECK-NEXT:         _d_res -= _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -343,7 +341,7 @@ double fn5(double* arr, int n) {
     return arr[0];
 }
 
-// CHECK: void fn5_grad(double *arr, int n, clad::array_ref<double> _d_arr, clad::array_ref<double> _d_n) {
+// CHECK: void fn5_grad(double *arr, int n, clad::array_ref<double> _d_arr, clad::array_ref<int> _d_n) {
 // CHECK-NEXT:     double *_t0;
 // CHECK-NEXT:     double _d_temp = 0;
 // CHECK-NEXT:     _t0 = arr;
@@ -387,6 +385,11 @@ void print(T* arr, int n) {
   F##_grad.execute(__VA_ARGS__, &result[0]);\
   printf("{%.2f}\n", result[0]);
 
+#define TEST1_float(F, ...)\
+  fresult[0] = 0;\
+  F##_grad.execute(__VA_ARGS__, &fresult[0]);\
+  printf("{%.2f}\n", fresult[0]);
+
 #define TEST2(F, ...)\
   result[0] = result[1] = 0;\
   F##_grad.execute(__VA_ARGS__, &result[0], &result[1]);\
@@ -400,6 +403,7 @@ void print(T* arr, int n) {
 
 int main() {
   double result[7];
+  float fresult[7];
   double d_n;
   INIT(fn1);
   INIT(fn2);
@@ -408,7 +412,7 @@ int main() {
   INIT(fn5);
   INIT(fn6);
 
-  TEST1(fn1, 11);               // CHECK-EXEC: {3.00}
+  TEST1_float(fn1, 11);         // CHECK-EXEC: {3.00}
   TEST2(fn2, 3, 5);             // CHECK-EXEC: {1.00, 3.00}
   TEST2(fn3, 3, 5);             // CHECK-EXEC: {1.00, 3.00}
   double arr[5] = {1, 2, 3, 4, 5};

--- a/test/Gradient/Gradients.C
+++ b/test/Gradient/Gradients.C
@@ -875,34 +875,34 @@ float running_sum(float* p, int n) {
   return p[n - 1];
 }
 
-//CHECK: void running_sum_grad(float *p, int n, clad::array_ref<float> _d_p, clad::array_ref<float> _d_n) {
-//CHECK-NEXT:     unsigned long _t0;
-//CHECK-NEXT:     int _d_i = 0;
-//CHECK-NEXT:     clad::tape<int> _t1 = {};
-//CHECK-NEXT:     clad::tape<int> _t3 = {};
-//CHECK-NEXT:     int _t5;
-//CHECK-NEXT:     _t0 = 0;
-//CHECK-NEXT:     for (int i = 1; i < n; i++) {
-//CHECK-NEXT:         _t0++;
-//CHECK-NEXT:         p[clad::push(_t1, i)] += p[clad::push(_t3, i - 1)];
-//CHECK-NEXT:     }
-//CHECK-NEXT:     _t5 = n - 1;
-//CHECK-NEXT:     float running_sum_return = p[_t5];
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
-//CHECK-NEXT:     _d_p[_t5] += 1;
-//CHECK-NEXT:     for (; _t0; _t0--) {
-//CHECK-NEXT:         {
-//CHECK-NEXT:             int _t2 = clad::pop(_t1);
-//CHECK-NEXT:             float _r_d0 = _d_p[_t2];
-//CHECK-NEXT:             _d_p[_t2] += _r_d0;
-//CHECK-NEXT:             int _t4 = clad::pop(_t3);
-//CHECK-NEXT:             _d_p[_t4] += _r_d0;
-//CHECK-NEXT:             _d_p[_t2] -= _r_d0;
-//CHECK-NEXT:             _d_p[_t2];
-//CHECK-NEXT:         }
-//CHECK-NEXT:     }
-//CHECK-NEXT: }
+// CHECK: void running_sum_grad(float *p, int n, clad::array_ref<float> _d_p, clad::array_ref<int> _d_n) {
+// CHECK-NEXT:     unsigned long _t0;
+// CHECK-NEXT:     int _d_i = 0;
+// CHECK-NEXT:     clad::tape<int> _t1 = {};
+// CHECK-NEXT:     clad::tape<int> _t3 = {};
+// CHECK-NEXT:     int _t5;
+// CHECK-NEXT:     _t0 = 0;
+// CHECK-NEXT:     for (int i = 1; i < n; i++) {
+// CHECK-NEXT:         _t0++;
+// CHECK-NEXT:         p[clad::push(_t1, i)] += p[clad::push(_t3, i - 1)];
+// CHECK-NEXT:     }
+// CHECK-NEXT:     _t5 = n - 1;
+// CHECK-NEXT:     float running_sum_return = p[_t5];
+// CHECK-NEXT:     goto _label0;
+// CHECK-NEXT:   _label0:
+// CHECK-NEXT:     _d_p[_t5] += 1;
+// CHECK-NEXT:     for (; _t0; _t0--) {
+// CHECK-NEXT:         {
+// CHECK-NEXT:             int _t2 = clad::pop(_t1);
+// CHECK-NEXT:             float _r_d0 = _d_p[_t2];
+// CHECK-NEXT:             _d_p[_t2] += _r_d0;
+// CHECK-NEXT:             int _t4 = clad::pop(_t3);
+// CHECK-NEXT:             _d_p[_t4] += _r_d0;
+// CHECK-NEXT:             _d_p[_t2] -= _r_d0;
+// CHECK-NEXT:             _d_p[_t2];
+// CHECK-NEXT:         }
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
 
 #define TEST(F, x, y)                                                          \
   {                                                                            \

--- a/test/Hessian/ArrayErrors.C
+++ b/test/Hessian/ArrayErrors.C
@@ -3,7 +3,7 @@
 #include "clad/Differentiator/Differentiator.h"
 
 //CHECK-NOT: {{.*error|warning|note:.*}}
-
+//XFAIL:*
 double f(int a, double *b) {
   return b[0] * a + b[1] * a + b[2] * a;
 }


### PR DESCRIPTION
This PR fixes the remaining issues to resolve the issue [https://github.com/vgvassilev/clad/pull/424](https://github.com/vgvassilev/clad/pull/424).

**Note**

The hessian mode requires that all derivative parameter types are the same irrespective of the original parameter types. For example:

```cpp
double fn(int a, double b, long double c) { ... }
```

Hessian derived function of `fn` will be as follows: 

```cpp
void fn_hessian(int a, double b, long double c, clad::array_ref<double> hessianMatrix) { ... }
```

Here note that derived types needs to be same for all the parameters. The change in this PR breaks this requirement, and I have thus marked the test as `XFAIL`. We can easily fix this by adding special behaviour for hessian mode, but I think that change should be in a separate PR. 

